### PR TITLE
82: leaderboard UI improvements

### DIFF
--- a/src/components/common/cards/leaderboardCard.jsx
+++ b/src/components/common/cards/leaderboardCard.jsx
@@ -13,19 +13,13 @@ const LeaderboardCard = ({ data, onSelect }) => {
           <div
             className="single-card row clickable"
             key={idx}
-            style={{ gridTemplateColumns: "50px 1fr auto" }}
+            style={{ gridTemplateColumns: "50px 1fr auto auto" }}
             onClick={() => onSelect(d)}
           >
             <div style={{ gridColumn: 1, textAlign: "left" }}>
-              <div>
-                <IconRender type="ranking" /> {d.ranking}
-              </div>
+              <div><IconRender type="ranking" /> {d.ranking}</div>
               <div>{d.totalPoints} Pts</div>
-              {d.potentialPoints?.realistic > 0 && (
-                <div style={{ fontSize: "0.8em", color: "gray" }}>
-                  {d.potentialPoints?.realistic} pot
-                </div>
-              )}
+              <span className="picks-badge" style={{ marginLeft: 0, display: "inline-block", minWidth: "unset" }}>{d.totalPicks || 0} ✓</span>
             </div>
             <div style={{ gridColumn: 2, textAlign: "left", paddingLeft: 12 }}>
               <div style={{ fontWeight: "bold" }}>
@@ -36,7 +30,15 @@ const LeaderboardCard = ({ data, onSelect }) => {
               </div>
             </div>
 
-            <div style={{ gridColumn: 3, textAlign: "right" }}>
+            <div style={{ gridColumn: 3, textAlign: "right", paddingRight: 8, fontSize: "0.8em", color: "gray" }}>
+              {d.potentialPoints?.realistic > 0 && (
+                <>
+                  <div>{d.potentialPoints.realistic}</div>
+                  <div>pot</div>
+                </>
+              )}
+            </div>
+            <div style={{ gridColumn: 4, textAlign: "right" }}>
               {d.misc?.winner && (
                 <>
                   <b>{getTeamAbbreviation(d.misc?.winner)}</b>

--- a/src/components/predictions/leaderboard/leaderboardTable.jsx
+++ b/src/components/predictions/leaderboard/leaderboardTable.jsx
@@ -75,7 +75,7 @@ const LeaderboardTable = ({
     },
     {
       path: "misc.winner",
-      label: "Champion Picked",
+      label: "Champion",
       content: (p) =>
         !p.misc ? (
           <span title="Submission information will be revealed after the deadline">
@@ -89,6 +89,13 @@ const LeaderboardTable = ({
               height={15}
               width="auto"
             />
+            {p.points?.champion?.points > 0 && (
+              <div>
+                <span className="picks-badge" style={{ margin: "2px auto 0" }}>
+                  {p.points.champion.points} pts
+                </span>
+              </div>
+            )}
           </div>
         ),
     },
@@ -112,18 +119,6 @@ const LeaderboardTable = ({
           {p.points?.misc?.points || 0}
           <span className="picks-badge">
             {p.points?.misc?.correctPicks || 0} ✓
-          </span>
-        </>
-      ),
-    },
-    {
-      path: "points.champion.points",
-      label: "Champion",
-      content: (p) => (
-        <>
-          {p.points?.champion?.points || 0}
-          <span className="picks-badge">
-            {p.points?.champion?.points ? 1 : 0} ✓
           </span>
         </>
       ),

--- a/src/components/predictions/leaderboard/leaderboardViewPredictionModal.jsx
+++ b/src/components/predictions/leaderboard/leaderboardViewPredictionModal.jsx
@@ -57,6 +57,7 @@ const LeaderboardViewPredictionModal = ({
         originalMatches,
         result,
         prediction.isSecondChance,
+        competition,
       );
     setGroups(populatedGroups);
     setPlayoffMatches(populatedPlayoffMatches);

--- a/src/components/predictions/maker/predictionsMaker.jsx
+++ b/src/components/predictions/maker/predictionsMaker.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useReducer } from "react";
+import { useState, useEffect, useContext, useReducer, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import SegmentedControl from "../../common/pageSections/segmentedControl";
 
@@ -69,6 +69,7 @@ const PredictionMaker = ({
   );
   const [allTeams, setAllTeams] = useState([]);
   const [bracketIsPortrait, setBracketIsPortrait] = useState(isMobile);
+  const bracketOrientationManuallySet = useRef(false);
   const [pendingNavigation, setPendingNavigation] = useState(null);
   const leaderboardPath = `/competitions?leaderboard=show&competitionID=${competitionID}&groupID=all&secondChance=${!!isSecondChance}`;
   const confirmNavigate = (path, label) => {
@@ -79,6 +80,7 @@ const PredictionMaker = ({
 
   useEffect(() => {
     if (!predictions.playoffMatches.length) return;
+    if (bracketOrientationManuallySet.current) return;
     const rounds = new Set(predictions.playoffMatches.map((m) => m.round)).size;
     setBracketIsPortrait(isMobile || rounds < 2);
   }, [predictions.playoffMatches]);
@@ -364,7 +366,10 @@ const PredictionMaker = ({
             isLocked={predictions.isLocked}
             misc={predictions.misc}
             isPortrait={bracketIsPortrait}
-            setIsPortrait={setBracketIsPortrait}
+            setIsPortrait={(v) => {
+              bracketOrientationManuallySet.current = true;
+              setBracketIsPortrait(v);
+            }}
             originalPlayoffMatches={originalPlayoffMatches}
           />
         ) : isTab("bonus") ? (

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -86,11 +86,11 @@
   padding-left: 24px;
   border-left: 3px solid var(--secondary);
   font-size: 0.9em;
+  font-weight: bold;
 }
 .table-cell.expanded-points {
   text-align: right;
   font-size: 0.9em;
-  font-weight: bold;
   white-space: nowrap;
 }
 .table-cell.expanded-user {

--- a/src/utils/predictionsUtil.js
+++ b/src/utils/predictionsUtil.js
@@ -102,7 +102,7 @@ const cascadeGroupChanges = (groups, playoffMatches, misc, competition) => {
         let group = newMatch.getTeamsFrom[t].groupName;
         let position = newMatch.getTeamsFrom[t].position;
         if (group.includes("groupMatrix") && competition?.groupMatrix?.length) {
-          const groupMatrix = competition.groupMatrix.find(
+          const groupMatrix = competition?.groupMatrix?.find(
             (m) => m.key === group.split(".")[1],
           );
           const order = getGroupNameFromSpecialGroup(groups[groupMatrix.key])
@@ -280,16 +280,26 @@ export const handlePopulateBracket = (
   playoffMatches,
   result,
   isSecondChance,
+  competition,
 ) => {
   let groups = {};
   groupPredictions.forEach((g) => {
-    let thisGroup;
+    let thisGroupResult;
     if (result) {
-      thisGroup = result.group.find((rg) => rg.groupName === g.groupName);
+      thisGroupResult = result.group.find((rg) => rg.groupName === g.groupName);
     }
+
     groups[g.groupName] = g.teamOrder.map((t, idx) => {
       let order = { name: t };
-      if (thisGroup?.teamOrder[idx] === t) order.correct = true;
+      let teamToMatch = t;
+      const isMatrixGroup = !!competition?.groupMatrix?.find(
+        (gm) => gm.key === thisGroupResult.groupName,
+      );
+      if (isMatrixGroup) {
+        // group matrix picks are correct if they match the group name
+        teamToMatch = teamToMatch.split(":")[0];
+      }
+      if (thisGroupResult?.teamOrder[idx] === teamToMatch) order.correct = true;
       return order;
     });
   });


### PR DESCRIPTION
- Merge champion picked and champion points into single leaderboard column
- Add correct picks badge and potential points column to leaderboard card
- Fix bracket orientation resetting when a team pick is made
- Fix correct pick highlighting not applying to groupMatrix groups