### PR TITLE
what if views

### DIFF
--- a/src/__test__/predictions/leaderboard/leaderboardWhatIfModal.test.js
+++ b/src/__test__/predictions/leaderboard/leaderboardWhatIfModal.test.js
@@ -1,0 +1,224 @@
+import { act, screen } from "@testing-library/react";
+import { renderWithContext, clickByText } from "../../testHelpers";
+import LeaderboardWhatIfModal from "../../../components/predictions/leaderboard/leaderboardWhatIfModal";
+
+const makePath = ({
+  champion = "Argentina",
+  sf1Winner = "Argentina",
+  sf2Winner = "France",
+  thirdPlace = null,
+  topOne = {
+    _id: "p1",
+    name: "My Picks",
+    userID: { name: "Alice" },
+    totalPoints: 50,
+  },
+  topTwo = {
+    _id: "p2",
+    name: "Your Picks",
+    userID: { name: "Bob" },
+    totalPoints: 40,
+  },
+  entryThree = {
+    _id: "p3",
+    name: "Their Picks",
+    userID: { name: "Carol" },
+    totalPoints: 30,
+  },
+} = {}) => ({
+  champion,
+  sf1Winner,
+  sf2Winner,
+  thirdPlace,
+  topSubmissions: [
+    {
+      rank: 1,
+      predictionID: { _id: topOne._id, name: topOne.name },
+      userID: topOne.userID,
+      totalPoints: topOne.totalPoints,
+    },
+    {
+      rank: 2,
+      predictionID: { _id: topTwo._id, name: topTwo.name },
+      userID: topTwo.userID,
+      totalPoints: topTwo.totalPoints,
+    },
+    {
+      rank: 3,
+      predictionID: { _id: entryThree._id, name: entryThree.name },
+      userID: entryThree.userID,
+      totalPoints: entryThree.totalPoints,
+    },
+  ],
+  secondChanceTopSubmissions: [],
+});
+
+const renderModal = async (props = {}) => {
+  await act(async () => {
+    renderWithContext(LeaderboardWhatIfModal, {
+      isOpen: true,
+      setIsOpen: jest.fn(),
+      whatIfData: null,
+      isSecondChance: false,
+      ...props,
+    });
+  });
+};
+
+describe("LeaderboardWhatIfModal", () => {
+  it("shows StatusNote when whatIfData is null", async () => {
+    await renderModal({ whatIfData: null });
+    expect(
+      screen.queryByText(
+        /scenarios will be available when the semi finals are set/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows StatusNote when whatIfData has no paths", async () => {
+    await renderModal({ whatIfData: { paths: [] } });
+    expect(
+      screen.queryByText(
+        /scenarios will be available when the semi finals are set/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the winning submission name and user", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    await clickByText("By Submission");
+    expect(screen.queryByText("My Picks")).toBeInTheDocument();
+    expect(screen.queryByText(/Alice/)).toBeInTheDocument();
+  });
+
+  it("shows scenario count", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    expect(screen.queryByText(/1 scenario/)).toBeInTheDocument();
+  });
+
+  it("shows plural scenario count when multiple paths share the same winner", async () => {
+    const path2 = makePath({
+      champion: "France",
+      sf1Winner: "France",
+      sf2Winner: "England",
+    });
+    await renderModal({ whatIfData: { paths: [makePath(), path2] } });
+    await clickByText("By Submission");
+    expect(screen.queryByText(/2 scenarios/)).toBeInTheDocument();
+  });
+
+  it("shows Champion label and team name", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    await clickByText("By Submission");
+    expect(screen.queryByText("Champion")).toBeInTheDocument();
+    expect(screen.queryAllByText("Argentina").length).toBeGreaterThan(0);
+  });
+
+  it("shows Finalist 1 and Finalist 2 labels", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    expect(screen.queryByText("Finalist 1")).toBeInTheDocument();
+    expect(screen.queryByText("Finalist 2")).toBeInTheDocument();
+  });
+
+  it("shows third place when present", async () => {
+    await renderModal({
+      whatIfData: { paths: [makePath({ thirdPlace: "Croatia" })] },
+    });
+    expect(screen.queryByText("3rd")).toBeInTheDocument();
+    expect(screen.queryByText("Croatia")).toBeInTheDocument();
+  });
+
+  it("does not show 3rd section when thirdPlace is null", async () => {
+    await renderModal({
+      whatIfData: { paths: [makePath({ thirdPlace: null })] },
+    });
+    expect(screen.queryByText("3rd")).not.toBeInTheDocument();
+  });
+
+  it("top-three entries are hidden before expanding", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    // rank 2 & 3 entries only appear in the expanded top-three, not in the winner header
+    expect(screen.queryByText("Your Picks")).not.toBeInTheDocument();
+    expect(screen.queryByText("Their Picks")).not.toBeInTheDocument();
+  });
+
+  it("expands top-three entries when the finalist row is clicked", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    await clickByText("Finalist 1");
+    expect(screen.queryByText("Your Picks")).toBeInTheDocument();
+    expect(screen.queryByText("Their Picks")).toBeInTheDocument();
+    expect(screen.queryByText("50 pts")).toBeInTheDocument();
+    expect(screen.queryByText("40 pts")).toBeInTheDocument();
+    expect(screen.queryByText("30 pts")).toBeInTheDocument();
+  });
+
+  it("collapses when the row is clicked again", async () => {
+    await renderModal({ whatIfData: { paths: [makePath()] } });
+    await clickByText("Finalist 1");
+    expect(screen.queryByText("Your Picks")).toBeInTheDocument();
+    await clickByText("Finalist 1");
+    expect(screen.queryByText("Your Picks")).not.toBeInTheDocument();
+  });
+
+  it("shows points range when compressed paths have different totals", async () => {
+    const path1 = makePath({
+      champion: "Argentina",
+      sf1Winner: "Argentina",
+      sf2Winner: "France",
+      thirdPlace: "Croatia",
+      topOne: {
+        _id: "p1",
+        name: "My Picks",
+        userID: { name: "Alice" },
+        totalPoints: 50,
+      },
+    });
+    const path2 = makePath({
+      champion: "Argentina",
+      sf1Winner: "Argentina",
+      sf2Winner: "France",
+      thirdPlace: "Morocco",
+      topOne: {
+        _id: "p1",
+        name: "My Picks",
+        userID: { name: "Alice" },
+        totalPoints: 66,
+      },
+    });
+    await renderModal({ whatIfData: { paths: [path1, path2] } });
+    await clickByText("Finalist 1");
+    expect(screen.queryByText("50-66 pts")).toBeInTheDocument();
+  });
+
+  it("uses secondChanceTopSubmissions when isSecondChance is true", async () => {
+    const path = {
+      ...makePath(),
+      secondChanceTopSubmissions: [
+        {
+          rank: 1,
+          predictionID: { _id: "sc1", name: "SC Picks" },
+          userID: { name: "Dave" },
+          totalPoints: 20,
+        },
+      ],
+    };
+    await renderModal({ whatIfData: { paths: [path] }, isSecondChance: true });
+    await clickByText("By Submission");
+    expect(screen.queryByText("SC Picks")).toBeInTheDocument();
+    expect(screen.queryByText(/Dave/)).toBeInTheDocument();
+    expect(screen.queryByText("My Picks")).not.toBeInTheDocument();
+  });
+
+  it("groups separate champions under the same winner card", async () => {
+    const path1 = makePath({ champion: "Argentina" });
+    const path2 = makePath({
+      champion: "France",
+      sf1Winner: "France",
+      sf2Winner: "England",
+    });
+    await renderModal({ whatIfData: { paths: [path1, path2] } });
+    await clickByText("By Submission");
+    const championLabels = screen.queryAllByText("Champion");
+    expect(championLabels).toHaveLength(2);
+  });
+});

--- a/src/__test__/predictions/leaderboard/predictionsLeaderboard.test.js
+++ b/src/__test__/predictions/leaderboard/predictionsLeaderboard.test.js
@@ -1,40 +1,41 @@
-import { apiResponse, clickByText, renderWithContext } from "../testHelpers"; // helpers must be imported at top of file as they contain mocking of useNavigate
+import { apiResponse, clickByText, renderWithContext } from "../../testHelpers"; // helpers must be imported at top of file as they contain mocking of useNavigate
 import { act, screen } from "@testing-library/react";
-import { getCompetition } from "../../services/competitionService";
+import { getCompetition } from "../../../services/competitionService";
 import {
   getLeaderboard,
   searchLeaderboard,
   getUnownedPrediction,
   forceRemovePredictionFromGroup,
   getTeamEliminations,
-} from "../../services/predictionsService";
+} from "../../../services/predictionsService";
 import {
   competition,
   prediction,
   leaderboard,
   result,
   user,
-} from "../testData";
-import { getMatches } from "../../services/matchService";
-import { getResult } from "../../services/resultsService";
-import { getGroupLink } from "../../services/groupsService";
-import PredictionsLeaderboard from "../../components/predictions/leaderboard/predictionsLeaderboard";
-import { mockHTMLContext } from "../mockHelpers";
-import { getTeamAbbreviation } from "../../utils/bracketsUtil";
+} from "../../testData";
+import { getMatches } from "../../../services/matchService";
+import { getResult, getWhatIfResult } from "../../../services/resultsService";
+import { getGroupLink } from "../../../services/groupsService";
+import PredictionsLeaderboard from "../../../components/predictions/leaderboard/predictionsLeaderboard";
+import { mockHTMLContext } from "../../mockHelpers";
+import { getTeamAbbreviation } from "../../../utils/bracketsUtil";
 
-jest.mock("../../services/groupsService", () => ({
+jest.mock("../../../services/groupsService", () => ({
   getGroupLink: jest.fn(),
 }));
-jest.mock("../../services/resultsService", () => ({
+jest.mock("../../../services/resultsService", () => ({
   getResult: jest.fn(),
+  getWhatIfResult: jest.fn(),
 }));
-jest.mock("../../services/matchService", () => ({
+jest.mock("../../../services/matchService", () => ({
   getMatches: jest.fn(),
 }));
-jest.mock("../../services/competitionService", () => ({
+jest.mock("../../../services/competitionService", () => ({
   getCompetition: jest.fn(),
 }));
-jest.mock("../../services/predictionsService", () => ({
+jest.mock("../../../services/predictionsService", () => ({
   getLeaderboard: jest.fn(),
   searchLeaderboard: jest.fn(),
   getUnownedPrediction: jest.fn(),
@@ -92,6 +93,12 @@ const renderWithProps = async (mocks = {}, props = {}, user = null) => {
     apiResponse(
       mocks?.getTeamEliminations?.data || [],
       mocks.getTeamEliminations?.status || 200,
+    ),
+  );
+  getWhatIfResult.mockReturnValue(
+    apiResponse(
+      mocks?.getWhatIfResult?.data || null,
+      mocks.getWhatIfResult?.status || 404,
     ),
   );
 
@@ -262,9 +269,7 @@ describe("PredictionsLeaderboard", () => {
       await renderWithProps({
         getMatches: { data: teamMatches },
       });
-      expect(
-        screen.queryByText("View Team Eliminations"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Team Eliminations")).not.toBeInTheDocument();
     });
 
     it("should show the button after the submission deadline", async () => {
@@ -272,9 +277,7 @@ describe("PredictionsLeaderboard", () => {
         getCompetition: { data: pastDeadlineCompetition },
         getMatches: { data: teamMatches },
       });
-      expect(
-        screen.queryByText("View Team Eliminations"),
-      ).toBeInTheDocument();
+      expect(screen.queryByText("Team Eliminations")).toBeInTheDocument();
     });
 
     it("should open the team picker when the button is clicked", async () => {
@@ -282,7 +285,7 @@ describe("PredictionsLeaderboard", () => {
         getCompetition: { data: pastDeadlineCompetition },
         getMatches: { data: teamMatches },
       });
-      await clickByText("View Team Eliminations");
+      await clickByText("Team Eliminations");
       expect(screen.queryByText("Argentina")).toBeInTheDocument();
       expect(screen.queryByText("Brazil")).toBeInTheDocument();
     });
@@ -296,7 +299,7 @@ describe("PredictionsLeaderboard", () => {
         },
         { competitionID: pastDeadlineCompetition._id, groupID: "all" },
       );
-      await clickByText("View Team Eliminations");
+      await clickByText("Team Eliminations");
       await clickByText("Argentina");
       expect(getTeamEliminations).toHaveBeenCalledTimes(1);
       expect(getTeamEliminations).toHaveBeenCalledWith(
@@ -318,7 +321,7 @@ describe("PredictionsLeaderboard", () => {
         },
         { competitionID: pastDeadlineCompetition._id, groupID: "all" },
       );
-      await clickByText("View Team Eliminations");
+      await clickByText("Team Eliminations");
       await clickByText("Argentina");
       expect(screen.queryByText("My Picks")).not.toBeInTheDocument();
       await clickByText("Semi Final");
@@ -336,12 +339,25 @@ describe("PredictionsLeaderboard", () => {
         },
         { competitionID: pastDeadlineCompetition._id, groupID: "all" },
       );
-      await clickByText("View Team Eliminations");
+      await clickByText("Team Eliminations");
       await clickByText("Argentina");
       await clickByText("Semi Final");
       expect(screen.queryByText("My Picks")).toBeInTheDocument();
       await clickByText("Semi Final");
       expect(screen.queryByText("My Picks")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Final Scenarios button", () => {
+    it("should show when there is no winner", async () => {
+      await renderWithProps();
+      expect(screen.queryByText("Final Scenarios")).toBeInTheDocument();
+    });
+    it("should hide when the competition has a winner", async () => {
+      await renderWithProps({
+        getResult: { data: { ...result, misc: { winner: "Argentina" } } },
+      });
+      expect(screen.queryByText("Final Scenarios")).not.toBeInTheDocument();
     });
   });
 

--- a/src/__test__/predictions/predictionsRedirect.test.js
+++ b/src/__test__/predictions/predictionsRedirect.test.js
@@ -12,7 +12,7 @@ import {
   getCompetition,
   getExpiredCompetitions,
 } from "../../services/competitionService";
-import { getResult } from "../../services/resultsService";
+import { getResult, getWhatIfResult } from "../../services/resultsService";
 import { getMatches } from "../../services/matchService";
 import { competition, leaderboard, matches } from "../testData";
 
@@ -31,6 +31,7 @@ jest.mock("../../services/matchService", () => ({
 }));
 jest.mock("../../services/resultsService", () => ({
   getResult: jest.fn(),
+  getWhatIfResult: jest.fn(),
 }));
 
 // suppress error caused by long running dispatch op in maker component
@@ -52,6 +53,7 @@ const renderWithProps = async (path = "", props = {}) => {
   getMatches.mockReturnValue(apiResponse(matches));
   getLeaderboard.mockReturnValue(apiResponse(leaderboard));
   getResult.mockReturnValue(apiResponse(null));
+  getWhatIfResult.mockReturnValue(apiResponse(null, 404));
 
   await act(async () => {
     renderWithContext(PredictionsRedirect, props, null, path);

--- a/src/components/predictions/leaderboard/bonusPickInfo.jsx
+++ b/src/components/predictions/leaderboard/bonusPickInfo.jsx
@@ -33,7 +33,7 @@ const BonusPickInfo = ({
     const submissionsRes = await getSubmissionsByMisc(
       competition._id,
       key,
-      team
+      team,
     );
     if (submissionsRes.status === 200) {
       setFilteredSubmissions(submissionsRes.data);
@@ -45,13 +45,6 @@ const BonusPickInfo = ({
 
   return (
     <>
-      <div style={{ height: 5 }} />
-      <button
-        className="btn btn-small btn-dark"
-        onClick={() => setIsOpen(true)}
-      >
-        View Current Bonus Pick Leaders
-      </button>
       <BasicModal isOpen={isOpen} onClose={setIsOpen}>
         {result.leaders.map((r, idx) => (
           <div key={idx} className="single-card light-bg">

--- a/src/components/predictions/leaderboard/leaderboardWhatIfModal.jsx
+++ b/src/components/predictions/leaderboard/leaderboardWhatIfModal.jsx
@@ -1,0 +1,335 @@
+import { useContext, useEffect, useState } from "react";
+import BasicModal from "../../common/modal/basicModal";
+import SingleTeamView from "../maker/singleTeamView";
+import IconRender from "../../common/icons/iconRender";
+import StatusNote from "../../common/pageSections/statusNote";
+import PillSort from "../../common/searchSort/pillSort";
+import LoadingContext from "../../../context/loadingContext";
+
+const WHAT_IF_TOP_N = 5;
+
+const ordinal = (n) => ["1st", "2nd", "3rd"][n - 1] || `${n}th`;
+
+const FinalistsRow = ({
+  sf1Winner,
+  sf2Winner,
+  thirdPlaces,
+  topSubmissions,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="whatif-finalists-row">
+      <div
+        className="whatif-finalists-header clickable"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <div className="whatif-path-semi">
+          <div className="result-section-label">Finalist 1</div>
+          <SingleTeamView teamName={sf1Winner} flagSide="right" />
+        </div>
+        <div className="whatif-path-semi">
+          <div className="result-section-label">Finalist 2</div>
+          <SingleTeamView teamName={sf2Winner} flagSide="left" />
+        </div>
+        {thirdPlaces.length > 0 && (
+          <div className="whatif-path-third">
+            <div className="result-section-label">3rd</div>
+            {thirdPlaces.map((t, i) => (
+              <div key={i} className="whatif-path-third-name">
+                {t}
+              </div>
+            ))}
+          </div>
+        )}
+        <IconRender type={expanded ? "up" : "down"} size={14} />
+      </div>
+      {expanded && (
+        <div className="whatif-top-three">
+          {topSubmissions.map((entry) => (
+            <div
+              key={entry.predictionID._id}
+              className="whatif-top-three-entry"
+            >
+              <span className="whatif-top-three-rank">{entry.rank}</span>
+              <span className="whatif-top-three-name">
+                {entry.predictionID.name}
+              </span>
+              <span className="whatif-top-three-user">{entry.userID.name}</span>
+              <span className="whatif-top-three-points">
+                {entry.pointsMin === entry.pointsMax
+                  ? `${entry.pointsMin} pts`
+                  : `${entry.pointsMin}-${entry.pointsMax} pts`}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const mergeTopSubmissions = (groupPaths, leaderKey) => {
+  const ref = groupPaths[0][leaderKey];
+  return ref.map((entry, i) => {
+    const allPoints = groupPaths
+      .map((p) => p[leaderKey][i]?.totalPoints)
+      .filter(Number.isFinite);
+    return {
+      ...entry,
+      pointsMin: Math.min(...allPoints),
+      pointsMax: Math.max(...allPoints),
+    };
+  });
+};
+
+const buildFinalistRows = (paths, leaderKey) => {
+  const groups = {};
+  paths.forEach((path) => {
+    const key = `${path.sf1Winner}|${path.sf2Winner}`;
+    if (!groups[key])
+      groups[key] = {
+        sf1Winner: path.sf1Winner,
+        sf2Winner: path.sf2Winner,
+        paths: [],
+      };
+    groups[key].paths.push(path);
+  });
+
+  const rows = [];
+  Object.values(groups).forEach(
+    ({ sf1Winner, sf2Winner, paths: groupPaths }) => {
+      if (groupPaths.length === 1) {
+        const p = groupPaths[0];
+        rows.push({
+          sf1Winner,
+          sf2Winner,
+          thirdPlaces: p.thirdPlace ? [p.thirdPlace] : [],
+          topSubmissions: mergeTopSubmissions(groupPaths, leaderKey),
+        });
+        return;
+      }
+
+      const ref = groupPaths[0][leaderKey];
+      const allSame = groupPaths.every((p) => {
+        const top = p[leaderKey];
+        return Array.from({ length: WHAT_IF_TOP_N - 1 }, (_, i) => i + 1).every(
+          (i) => top[i]?.predictionID._id === ref[i]?.predictionID._id,
+        );
+      });
+
+      if (allSame) {
+        rows.push({
+          sf1Winner,
+          sf2Winner,
+          thirdPlaces: groupPaths.map((p) => p.thirdPlace).filter(Boolean),
+          topSubmissions: mergeTopSubmissions(groupPaths, leaderKey),
+        });
+      } else {
+        groupPaths.forEach((p) => {
+          rows.push({
+            sf1Winner,
+            sf2Winner,
+            thirdPlaces: p.thirdPlace ? [p.thirdPlace] : [],
+            topSubmissions: mergeTopSubmissions([p], leaderKey),
+          });
+        });
+      }
+    },
+  );
+
+  return rows;
+};
+
+const ChampionGroup = ({ champion, paths, leaderKey }) => (
+  <div className="whatif-path-row">
+    <div className="whatif-path-champion">
+      <div className="result-section-label">Champion</div>
+      <SingleTeamView teamName={champion} />
+    </div>
+    {buildFinalistRows(paths, leaderKey).map((row, i) => (
+      <FinalistsRow
+        key={i}
+        sf1Winner={row.sf1Winner}
+        sf2Winner={row.sf2Winner}
+        thirdPlaces={row.thirdPlaces}
+        topSubmissions={row.topSubmissions}
+      />
+    ))}
+  </div>
+);
+
+const ChampionCard = ({ champion, paths, leaderKey }) => (
+  <div className="single-card whatif-winner-card">
+    <div className="whatif-winner-name">
+      <SingleTeamView teamName={champion} />
+    </div>
+    <div className="whatif-winner-meta">
+      {paths.length} scenario{paths.length !== 1 ? "s" : ""}
+    </div>
+    {buildFinalistRows(paths, leaderKey).map((row, i) => (
+      <FinalistsRow
+        key={i}
+        sf1Winner={row.sf1Winner}
+        sf2Winner={row.sf2Winner}
+        thirdPlaces={row.thirdPlaces}
+        topSubmissions={row.topSubmissions}
+      />
+    ))}
+  </div>
+);
+
+const groupByChampion = (paths) => {
+  const groups = {};
+  paths.forEach((path) => {
+    if (!groups[path.champion]) groups[path.champion] = [];
+    groups[path.champion].push(path);
+  });
+  return Object.entries(groups);
+};
+
+const UserScenariosView = ({ allPaths, user, leaderKey }) => {
+  const byRank = {};
+  allPaths.forEach((path) => {
+    const entry = path[leaderKey].find(
+      (e) => String(e.userID._id) === String(user._id),
+    );
+    if (!entry) return;
+    if (!byRank[entry.rank]) byRank[entry.rank] = [];
+    byRank[entry.rank].push(path);
+  });
+
+  if (!Object.keys(byRank).length)
+    return (
+      <StatusNote>
+        You don&apos;t appear in the top {WHAT_IF_TOP_N} in any scenario.
+      </StatusNote>
+    );
+
+  return Object.entries(byRank)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([rank, paths]) => (
+      <div key={rank} className="single-card whatif-winner-card">
+        <div className="whatif-winner-name">Finish {ordinal(Number(rank))}</div>
+        <div className="whatif-winner-meta">
+          {paths.length} scenario{paths.length !== 1 ? "s" : ""}
+        </div>
+        {groupByChampion(paths).map(([champion, championPaths]) => (
+          <ChampionGroup
+            key={champion}
+            champion={champion}
+            paths={championPaths}
+            leaderKey={leaderKey}
+          />
+        ))}
+      </div>
+    ));
+};
+
+const LeaderboardWhatIfModal = ({
+  isOpen,
+  setIsOpen,
+  whatIfData,
+  isSecondChance,
+}) => {
+  const { user } = useContext(LoadingContext);
+  const [mappedByEntry, setMappedByEntry] = useState({});
+  const [mappedByChampion, setMappedByChampion] = useState([]);
+  const [view, setView] = useState("champion");
+
+  const leaderKey = isSecondChance
+    ? "secondChanceTopSubmissions"
+    : "topSubmissions";
+
+  const viewOptions = [
+    { label: "By Champion", value: "champion" },
+    { label: "By Submission", value: "submissions" },
+    ...(user ? [{ label: "My Scenarios", value: "mine" }] : []),
+  ];
+
+  useEffect(() => {
+    const winners = {};
+    whatIfData?.paths?.forEach((path) => {
+      const top = path[leaderKey][0];
+      if (!top) return;
+      const id = top.predictionID._id;
+      if (winners[id]) winners[id].push(path);
+      else winners[id] = [path];
+    });
+    Object.values(winners).forEach((paths) =>
+      paths.sort((a, b) => a.champion.localeCompare(b.champion)),
+    );
+    setMappedByEntry(winners);
+    setMappedByChampion(
+      groupByChampion(whatIfData?.paths || []).sort(([a], [b]) =>
+        a.localeCompare(b),
+      ),
+    );
+  }, [whatIfData, isSecondChance]);
+
+  const hasData = !!Object.keys(mappedByEntry).length;
+
+  return (
+    <BasicModal
+      isOpen={isOpen}
+      onClose={setIsOpen}
+      header={<div className="standout-header">Final Scenarios</div>}
+      style={{ maxHeight: "80%", maxWidth: 400 }}
+    >
+      {!hasData ? (
+        <StatusNote>
+          Scenarios will be available when the semi finals are set
+        </StatusNote>
+      ) : (
+        <>
+          <PillSort
+            onFilter={setView}
+            options={viewOptions}
+            selectedValue={view}
+          />
+          {view === "submissions" &&
+            Object.entries(mappedByEntry).map(([id, paths]) => {
+              const top = paths[0][leaderKey][0];
+              return (
+                <div key={id} className="single-card whatif-winner-card">
+                  <div className="whatif-winner-name">
+                    {top.predictionID.name}
+                  </div>
+                  <div className="whatif-winner-meta">
+                    {top.userID.name} &middot; {paths.length} scenario
+                    {paths.length !== 1 ? "s" : ""}
+                  </div>
+                  {groupByChampion(paths).map(([champion, championPaths]) => (
+                    <ChampionGroup
+                      key={champion}
+                      champion={champion}
+                      paths={championPaths}
+                      leaderKey={leaderKey}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+          {view === "champion" &&
+            mappedByChampion.map(([champion, paths]) => (
+              <ChampionCard
+                key={champion}
+                champion={champion}
+                paths={paths}
+                leaderKey={leaderKey}
+              />
+            ))}
+          {view === "mine" && (
+            <UserScenariosView
+              allPaths={whatIfData?.paths || []}
+              user={user}
+              leaderKey={leaderKey}
+            />
+          )}
+        </>
+      )}
+    </BasicModal>
+  );
+};
+
+export default LeaderboardWhatIfModal;

--- a/src/components/predictions/leaderboard/predictionsLeaderboard.jsx
+++ b/src/components/predictions/leaderboard/predictionsLeaderboard.jsx
@@ -15,7 +15,7 @@ import { getMatches } from "../../../services/matchService";
 import { getCompetition } from "../../../services/competitionService";
 import PageSelection from "../../common/pageSections/pageSelection";
 import TeamSelectComponent from "../maker/teamSelectComponent";
-import { getResult } from "../../../services/resultsService";
+import { getResult, getWhatIfResult } from "../../../services/resultsService";
 import Confirm from "../../common/modal/confirm";
 import BonusPickInfo from "./bonusPickInfo";
 import IconRender from "../../common/icons/iconRender";
@@ -23,6 +23,7 @@ import DualNavLink from "../../common/pageSections/dualNavLink";
 import { submissionDeadlinePassed } from "../../../utils/competitionsUtil";
 import { filterRealTeams } from "../../../utils/predictionsUtil";
 import LeaderboardTeamEliminationsModal from "./leaderboardTeamEliminationsModal";
+import LeaderboardWhatIfModal from "./leaderboardWhatIfModal";
 
 const PredictionsLeaderboard = ({ competitionID, groupID, isSecondChance }) => {
   let navigate = useNavigate();
@@ -47,6 +48,8 @@ const PredictionsLeaderboard = ({ competitionID, groupID, isSecondChance }) => {
   const [selectedTeam, setSelectedTeam] = useState(null);
   const [teamEliminationsOpen, setTeamEliminationsOpen] = useState(false);
   const [teamEliminations, setTeamEliminations] = useState([]);
+  const [whatIfOpen, setWhatIfOpen] = useState(false);
+  const [whatIfData, setWhatIfData] = useState(null);
 
   const loadLeaderboard = async (
     selectedPage,
@@ -109,6 +112,9 @@ const PredictionsLeaderboard = ({ competitionID, groupID, isSecondChance }) => {
           setResult(resultRes.data);
           // do not give error here, results may not exist yet
         }
+        const whatIfRes = await getWhatIfResult(competitionRes.data.code);
+        if (whatIfRes && whatIfRes.status === 200)
+          setWhatIfData(whatIfRes.data);
       } else toast.error(competitionRes.data);
     } else toast.error(matchesRes.data);
 
@@ -191,19 +197,37 @@ const PredictionsLeaderboard = ({ competitionID, groupID, isSecondChance }) => {
             Invite Users
           </button>
         )}
-        {allTeams.length > 0 && submissionDeadlinePassed(competition) && (
-          <TeamSelectComponent
-            teams={allTeams.map((t) => ({ value: t }))}
-            onSelect={(team) => {
-              setSelectedTeam(team);
-              setTeamEliminations([]);
-              setTeamEliminationsOpen(true);
-            }}
-            title="View Team Eliminations"
-            subtitle={`Select a team to view the breakdown of predicted elimination rounds across all ${groupInfo ? groupInfo.name + " " : ""}submissions`}
-            compact
-          />
-        )}
+        <div className="btn-toolbar">
+          {!result?.misc?.winner && !groupInfo && (
+            <button
+              className="btn btn-sm btn-secondary"
+              onClick={() => setWhatIfOpen(true)}
+            >
+              Final Scenarios
+            </button>
+          )}
+          {allTeams.length > 0 && submissionDeadlinePassed(competition) && (
+            <TeamSelectComponent
+              teams={allTeams.map((t) => ({ value: t }))}
+              onSelect={(team) => {
+                setSelectedTeam(team);
+                setTeamEliminations([]);
+                setTeamEliminationsOpen(true);
+              }}
+              title="Team Eliminations"
+              subtitle={`Select a team to view the breakdown of predicted elimination rounds across all ${groupInfo ? groupInfo.name + " " : ""}submissions`}
+              compact
+            />
+          )}
+          {!isSecondChance && !!result?.leaders?.length && (
+            <button
+              className="btn btn-small btn-light"
+              onClick={() => setBonusPicksOpen(true)}
+            >
+              Bonus Pick Leaders
+            </button>
+          )}
+        </div>
       </div>
       {competition.secondChance && !groupInfo && (
         <span
@@ -307,6 +331,12 @@ const PredictionsLeaderboard = ({ competitionID, groupID, isSecondChance }) => {
           this group you should change the group passcode.
         </Confirm>
       )}
+      <LeaderboardWhatIfModal
+        isOpen={whatIfOpen}
+        setIsOpen={setWhatIfOpen}
+        whatIfData={whatIfData}
+        isSecondChance={isSecondChance}
+      />
       <LeaderboardTeamEliminationsModal
         isOpen={teamEliminationsOpen}
         setIsOpen={(val) => {

--- a/src/components/predictions/maker/singleTeamView.jsx
+++ b/src/components/predictions/maker/singleTeamView.jsx
@@ -2,7 +2,15 @@ import logos from "../../../textMaps/logos";
 import { findCountryLogo } from "../../../utils/predictionsUtil";
 import ExternalImage from "../../common/image/externalImage";
 
-const SingleTeamView = ({ teamName, onSelect, asCard }) => {
+const SingleTeamView = ({ teamName, onSelect, asCard, flagSide }) => {
+  const flag = (
+    <ExternalImage
+      uri={logos[findCountryLogo(teamName)]}
+      height={15}
+      width="auto"
+    />
+  );
+
   return (
     <div
       className={
@@ -13,21 +21,13 @@ const SingleTeamView = ({ teamName, onSelect, asCard }) => {
       onClick={onSelect ? () => onSelect(teamName) : null}
     >
       <div style={{ gridColumn: 1 }}>
-        <ExternalImage
-          uri={logos[findCountryLogo(teamName)]}
-          height={15}
-          width="auto"
-        />
+        {flagSide !== "right" && flag}
       </div>
-      <div style={{ gridColumn: 2, fontWeight: asCard ? "" : "bold" }}>
+      <div className="single-team-name" style={{ gridColumn: 2, fontWeight: asCard ? "" : "bold" }}>
         {teamName}
       </div>
       <div style={{ gridColumn: 3 }}>
-        <ExternalImage
-          uri={logos[findCountryLogo(teamName)]}
-          height={15}
-          width="auto"
-        />
+        {flagSide !== "left" && flag}
       </div>
     </div>
   );

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -1,3 +1,18 @@
+.btn-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  max-width: calc(100% - 48px);
+  gap: 2px;
+  padding: 4px 10px;
+  margin: 8px auto 0;
+  background-color: var(--light-grey);
+  border: 1px solid var(--medium-grey);
+  border-radius: 8px;
+}
+
 .picks-badge {
   display: block;
   width: fit-content;
@@ -110,12 +125,19 @@ a.btn {
   --btn-hover-bg: var(--minus10-danger-bg-color);
   --btn-text: var(--light-text);
 }
+.btn-secondary {
+  --btn-bg: var(--secondary);
+  --btn-border: var(--minus10-secondary);
+  --btn-hover-bg: var(--minus10-secondary);
+  --btn-text: var(--light-text);
+}
 
 /* --- Shared state rules for all variants --- */
 .btn-light,
 .btn-dark,
 .btn-info,
-.btn-danger {
+.btn-danger,
+.btn-secondary {
   background-color: var(--btn-bg);
   border-color: var(--btn-border);
   color: var(--btn-text);
@@ -123,7 +145,8 @@ a.btn {
 .btn-light:hover,
 .btn-dark:hover,
 .btn-info:hover,
-.btn-danger:hover {
+.btn-danger:hover,
+.btn-secondary:hover {
   background-color: var(--btn-hover-bg);
   color: var(--btn-text);
 }
@@ -134,7 +157,9 @@ a.btn {
 .btn-info:focus,
 .btn-info.focus,
 .btn-danger:focus,
-.btn-danger.focus {
+.btn-danger.focus,
+.btn-secondary:focus,
+.btn-secondary.focus {
   background-color: var(--btn-bg);
   border-color: var(--btn-bg);
   box-shadow: 0 0 0 0.2rem var(--btn-hover-bg);
@@ -147,7 +172,9 @@ a.btn {
 .btn-info.disabled,
 .btn-info:disabled,
 .btn-danger.disabled,
-.btn-danger:disabled {
+.btn-danger:disabled,
+.btn-secondary.disabled,
+.btn-secondary:disabled {
   background-color: var(--medium-grey);
   border-color: var(--medium-grey);
   color: var(--darker-grey);
@@ -163,7 +190,10 @@ a.btn {
 .show > .btn-info.dropdown-toggle,
 .btn-danger:not(:disabled):not(.disabled):active,
 .btn-danger:not(:disabled):not(.disabled).active,
-.show > .btn-danger.dropdown-toggle {
+.show > .btn-danger.dropdown-toggle,
+.btn-secondary:not(:disabled):not(.disabled):active,
+.btn-secondary:not(:disabled):not(.disabled).active,
+.show > .btn-secondary.dropdown-toggle {
   background-color: var(--btn-hover-bg);
   border-color: var(--btn-hover-bg);
   color: var(--btn-text);
@@ -179,7 +209,10 @@ a.btn {
 .show > .btn-info.dropdown-toggle:focus,
 .btn-danger:not(:disabled):not(.disabled):active:focus,
 .btn-danger:not(:disabled):not(.disabled).active:focus,
-.show > .btn-danger.dropdown-toggle:focus {
+.show > .btn-danger.dropdown-toggle:focus,
+.btn-secondary:not(:disabled):not(.disabled):active:focus,
+.btn-secondary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-secondary.dropdown-toggle:focus {
   box-shadow: 0 0 0 0.2rem var(--btn-hover-bg);
   color: var(--btn-text);
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -17,8 +17,9 @@
   --minus20-info-bg-color: #cc66ff;
   --alert-bg-color: #831fe0;
   --secondary: #831fe0;
+  --minus10-secondary: #6b18b8;
   --main-bg-color: #831fe0;
---muted-bg-color: #e6d2f9;
+  --muted-bg-color: #e6d2f9;
   --danger-bg-color: #cc0000;
   --minus10-danger-bg-color: #990000;
   --minus20-danger-bg-color: #660000;

--- a/src/css/pageSection.css
+++ b/src/css/pageSection.css
@@ -834,3 +834,108 @@
   border-radius: 12px;
   white-space: nowrap;
 }
+
+.whatif-winner-card {
+  margin-bottom: 12px;
+}
+
+.whatif-winner-name {
+  font-weight: bold;
+  font-size: 1.3em;
+  margin-bottom: 2px;
+}
+
+.whatif-winner-meta {
+  font-size: 0.85em;
+  color: gray;
+  margin-bottom: 4px;
+}
+
+.whatif-path-row {
+  margin: 8px 12px 0;
+  padding: 10px 8px;
+  border-radius: 5px;
+  background-color: var(--muted-bg-color);
+  box-shadow: 0 1px 3px var(--minus10-info-bg-color);
+}
+
+.whatif-path-champion {
+  text-align: center;
+  margin-bottom: 6px;
+}
+
+.whatif-finalists-row {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--light-grey);
+}
+
+.whatif-finalists-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.whatif-top-three {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.whatif-top-three-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  background-color: var(--light-text);
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.whatif-top-three-rank {
+  font-weight: bold;
+  min-width: 16px;
+  color: var(--secondary);
+}
+
+.whatif-top-three-name {
+  flex: 1;
+  font-weight: bold;
+}
+
+.whatif-top-three-user {
+  color: var(--darker-grey);
+}
+
+.whatif-top-three-points {
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.whatif-path-semi {
+  flex: 1;
+  text-align: center;
+}
+
+@media (max-width: 380px) {
+  .whatif-path-semi .single-team-name {
+    display: none;
+  }
+
+  .whatif-path-semi .row {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.whatif-path-third {
+  text-align: center;
+  min-width: 60px;
+  flex-shrink: 0;
+}
+
+.whatif-path-third-name {
+  font-size: 0.85em;
+  font-weight: bold;
+}

--- a/src/services/resultsService.js
+++ b/src/services/resultsService.js
@@ -23,3 +23,11 @@ export async function calculateCompetition(code) {
     return ex.response;
   }
 }
+
+export async function getWhatIfResult(code) {
+  try {
+    return await http.get(http.results + "/whatif/" + code);
+  } catch (ex) {
+    return ex.response;
+  }
+}

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -12,7 +12,7 @@ const commonModalStyles = {
 };
 
 export const modalStyle = {
-  overlay: { zIndex: 50 },
+  overlay: { zIndex: 150 },
   content: {
     minHeight: "auto",
     maxHeight: "75%",


### PR DESCRIPTION
- resultsService — getWhatIfResult(code) fetches pre-computed paths from the backend
- predictionsLeaderboard — loads what-if data on mount, shows "Final Scenarios" button when the competition is still live (hidden once a winner is recorded)
- leaderboardWhatIfModal — three-view modal with pill switcher:
  - By Champion (default) — one card per possible champion, finalist rows expand to show top-N leaderboard for that scenario
  - By Submission — one card per submission that can finish 1st, grouped by which champion gets them there
  - My Scenarios — logged-in users only; shows which finish position they can achieve and what needs to happen, or a status note if they don't appear in any path's top N
- Finalist rows use safe compression: paths with the same finalist pair are merged into one row (with a points range) only when positions 2–N of the leaderboard are identical across those paths
- singleTeamView — added flagSide prop ("left" / "right") for single-flag display in tight layouts; responsive CSS hides team name below 380 px
- Modal z-index bumped to sit above the navbar